### PR TITLE
Fix CSV load error handling

### DIFF
--- a/model.py
+++ b/model.py
@@ -137,10 +137,14 @@ class InventoryModel:
                 reader = csv.DictReader(f)
                 for row in reader:
                     records.append(row)
-        except Exception as e:
-            print(f"读取记录时发生错误: {e}")
-            # 如果文件不存在或读取失败，确保文件被初始化
+        except FileNotFoundError:
+            # 文件不存在时初始化一个空的 CSV
             self.initialize_csv()
+            return []
+        except Exception as e:
+            # 其他异常直接打印出来，避免静默失败
+            print(f"读取记录时发生错误: {e}")
+            return []
         return records
     
     def partial_outbound(self, order_number: str, outbound_quantity: int, tracking_number: str, counter: str) -> bool:


### PR DESCRIPTION
## Summary
- improve `InventoryModel.get_all_records` so that we only call `initialize_csv` when the file is missing
- log other read errors and return an empty list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5db9d974832f8262330297476b14